### PR TITLE
arrivals-impala-osn() queries departures!

### DIFF
--- a/R/osn-impala.R
+++ b/R/osn-impala.R
@@ -163,7 +163,7 @@ arrivals_impala_osn <- function(session, apt, wef, til=NULL) {
     "SELECT {COLUMNS} ",
     "FROM {TABLES} ",
     "WHERE ",
-    "estdepartureairport like '%{APT}%' ",
+    "estarrivalairport like '%{APT}%' ",
     " and firstseen >= {WEF} ",
     " and firstseen <  {TIL};",
     COLUMNS = stringr::str_c(columns, collapse = ","),


### PR DESCRIPTION
The query for arrivals-impala-osn() still points to 'SELECT ... WHERE estdepartureairport like ...'.
Changed departure to arrival to make it work.